### PR TITLE
403 AWS WAF workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
 
 ### Fixed bugs:
 - Removed errant space from Greek language in `EXPERTISE_LANGUAGES`
-- TT-1487 403 to work around for AWS WAF error 
 
 ## [16.2.0](https://pypi.org/project/directory-constants/16.2.0/) (2019-04-26)
 [Full Changelog](https://github.com/uktrade/directory-constants/pull/93/files)
@@ -47,3 +46,6 @@
 
 ### Implemented enhancements
 - Added `investment-support-directory` and `investment-support-directory/search` to FAS urls
+
+### Fixed bugs:
+- TT-1487 403 to work around for AWS WAF error 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Fixed bugs:
 - Removed errant space from Greek language in `EXPERTISE_LANGUAGES`
+- TT-1487 403 to work around for AWS WAF error 
 
 ## [16.2.0](https://pypi.org/project/directory-constants/16.2.0/) (2019-04-26)
 [Full Changelog](https://github.com/uktrade/directory-constants/pull/93/files)

--- a/directory_constants/expertise.py
+++ b/directory_constants/expertise.py
@@ -21,9 +21,9 @@ HUMAN_RESOURCES = [
     'Payroll',
     'Salary benchmarking and employee benefits',
     'Sourcing and hiring',
+    'Succession planning',
     'Staff management and progression',
     'Staff onboarding',
-    'Succession planning',
 ]
 
 LEGAL = [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_constants',
-    version='16.7.0',
+    version='16.7.1',
     url='https://github.com/uktrade/directory-constants',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
This is a strange one :-)
WAF is causing issue with 'staff onboarding being in the middle'
disabling WAF would make us vulnerable  so work around is to change the ordering so it's at the end of the query string. 

