### PR TITLE
Give the new international route a dedicated env-var.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
-## [19.1.0](https://pypi.org/project/directory-constants/19.0.0/) (2019-09-03)
+## [20.0.0]((https://pypi.org/project/directory-constants/20.0.0/) (2019-09-05))
+### Fixed Bugs
+- CI-405: International URL now reads from a new env-var instead of the old one.
+
+### Breaking Changes
+- Applications will need to add a new `DIRECTORY_CONSTANTS_URL_INTERNATIONAL` settings parameter to set the root international URL
+- The `DIRECTORY_CONSTANTS_URL_GREAT_INTERNATIONAL` is no longer used.
+
+## [19.1.0](https://pypi.org/project/directory-constants/19.1.0/) (2019-09-03)
 [Full Changelog](https://github.com/uktrade/directory-constants/pull/119/files)
 ### Implemented Enhancements
 - CI-405: Add module definitions to allow `urls.domestic` and `urls.international`

--- a/directory_constants/urls/international.py
+++ b/directory_constants/urls/international.py
@@ -1,7 +1,7 @@
 from directory_constants.helpers import UrlString, get_url
 from directory_constants.urls.domestic import INTERNATIONAL_CONTACT_TRIAGE
 
-HOME = UrlString(get_url('DIRECTORY_CONSTANTS_URL_GREAT_INTERNATIONAL', 'https://great.gov.uk/international'))
+HOME = UrlString(get_url('DIRECTORY_CONSTANTS_URL_INTERNATIONAL', 'https://great.gov.uk/international/'))
 CONTENT_ROOT = HOME / 'content'
 
 # about the UK

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_constants',
-    version='19.1.0',
+    version='20.0.0',
     url='https://github.com/uktrade/directory-constants',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
Avoids issues with stray `/contents/` in the one currently in use.

To do (delete all that do not apply):

 - [x] Changelog entry added.
