### PR TITLE
Extend Django support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [20.12.0](https://pypi.org/project/directory-constants/20.12.0/) (2020-03-24)
+## [21.0.0](https://pypi.org/project/directory-constants/20.12.0/) (2020-03-24)
 [Full Changelog](https://github.com/uktrade/directory-constants/pull/133/files)
 ### Implemented Enhancements
 - Extend Django support to current latest release v3.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [21.0.0](https://pypi.org/project/directory-constants/20.12.0/) (2020-03-24)
+## [20.12.0](https://pypi.org/project/directory-constants/20.12.0/) (2020-03-24)
 [Full Changelog](https://github.com/uktrade/directory-constants/pull/133/files)
 ### Implemented Enhancements
 - Extend Django support to current latest release v3.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [20.12.0](https://pypi.org/project/directory-constants/20.12.0/) (2020-03-24)
+[Full Changelog](https://github.com/uktrade/directory-constants/pull/133/files)
+### Implemented Enhancements
+- Extend Django support to current latest release v3.0.5
+
 ## [20.11.0](https://pypi.org/project/directory-constants/20.11.0/) (2020-01-29)
 [Full Changelog](https://github.com/uktrade/directory-constants/pull/132/files)
 ### Implemented Enhancements

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_constants',
-    version='20.11.0',
+    version='21.0.0',
     url='https://github.com/uktrade/directory-constants',
     license='MIT',
     author='Department for International Trade',
@@ -44,6 +44,7 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0.5',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_constants',
-    version='21.0.0',
+    version='20.12.0',
     url='https://github.com/uktrade/directory-constants',
     license='MIT',
     author='Department for International Trade',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        'django>=1.11,<3.0a1',
+        'django>=1.11,<3.0.5',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Extend up to 3.0.5 which is the latest django release

Planning to use the constants in Enquiry management tool repo which requires support for Django >=3.0.3. This PR extends support to 3.0.5 which is the current latest release.

To do (delete all that do not apply):

 - [x] Changelog entry added.
