### PR TITLE
NOTICKET - Update Django to security-patched version 3.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [20.28.1](https://pypi.org/project/directory-constants/20.28.1/) (2021-05-14)
+- NOTICKET - Update Django to security-patched version 3.1.11
+
 ## [20.28.0](https://pypi.org/project/directory-constants/20.28.0/) (2021-04-28)
 [Full Changelog](https://github.com/uktrade/directory-constants/pull/155/files)
 - GP2-2358 - Update contact us URL for mange

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_constants',
-    version='20.28.0',
+    version='20.28.1',
     url='https://github.com/uktrade/directory-constants',
     license='MIT',
     author='Department for International Trade',
@@ -22,7 +22,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        'django>=1.11,<=3.1.7',
+        'django>=1.11,<=3.1.11',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
To keep Dependabot happy, even thought we don't actually use/run with this version of Django from this repo

 - [X] Changelog entry added.
 - [X] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled. **DOESN'T LOOK LIKE THIS REPO HAS A REQUIREMENTS.TXT - it just uses setup.py**
