### PR TITLE
Dependencies upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/python:3.6.6
+      - image: circleci/python:3.9
     steps:
       - checkout
       - run:
@@ -13,7 +13,7 @@ jobs:
             make test
   publish_to_pypi:
     docker:
-      - image: circleci/python:3.6.6
+      - image: circleci/python:3.9
     steps:
       - checkout
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [21.0.0](https://pypi.org/project/directory-constants/21.0.0/) (2021-06-24)
+- NOTICKET - Updated Django
+
 ## [20.28.1](https://pypi.org/project/directory-constants/20.28.1/) (2021-05-14)
 - NOTICKET - Update Django to security-patched version 3.1.11
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_constants',
-    version='20.28.1',
+    version='21.0.0',
     url='https://github.com/uktrade/directory-constants',
     license='MIT',
     author='Department for International Trade',
@@ -22,7 +22,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        'django>=1.11,<=3.1.11',
+        'django>=2.2.24,<=3.1.11',
     ],
     extras_require={
         'test': [
@@ -40,7 +40,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',


### PR DESCRIPTION
Minimum Django requirement is 2.2.24 due to below vulnerability 

CVE-2021-33203
