### PR TITLE
Upgrade django dependency to less than 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [22.0.2](https://pypi.org/project/directory-constants/22.0.2/) (2023-2-15)
+- KLS-398 - Update django requires to less than 4.0.0
+
 ## [22.0.0](https://pypi.org/project/directory-constants/22.0.0/) (2022-8-18)
 - GLS-383 - Dependencies upgrade
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="directory_constants",
-    version="22.0.1",
+    version="22.0.2",
     url="https://github.com/uktrade/directory-constants",
     license="MIT",
     author="Department for International Trade",
@@ -22,7 +22,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "django>=2.2.28,<=3.2.16",
+        "django>=2.2.28,<4.0.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
This PR updates the max version of django required to run the package to 4.0.0

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
