### PR TITLE
bump django to 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## [23.1.1]
+[Full Changelog](https://github.com/uktrade/directory-constants/pull/177) (2023-07-06)
+### Enhancement
+- KLS-822 - Upgrade Django to 4.2.3
 ## [23.1.0]
 [Full Changelog](https://github.com/uktrade/directory-constants/pull/176) (2023-05-17)
 ### Enhancement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## [23.1.1]
-[Full Changelog](https://github.com/uktrade/directory-constants/pull/177) (2023-07-06)
+[Full Changelog](https://github.com/uktrade/directory-constants/pull/179) (2023-07-06)
 ### Enhancement
 - KLS-822 - Upgrade Django to 4.2.3
 ## [23.1.0]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="directory_constants",
-    version="23.1.0",
+    version="23.1.1",
     url="https://github.com/uktrade/directory-constants",
     license="MIT",
     author="Department for Business and Trade",
@@ -22,7 +22,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "django>=3.2.18,<=4.2.1",
+        "django>=3.2.18,<=4.2.3",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Bump Django to 4.2.3 (LTS)

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.

