### PR TITLE
KLS-1733 Upgrade Django 4.2x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="directory_constants",
-    version="23.1.2",
+    version="24.0.0",
     url="https://github.com/uktrade/directory-constants",
     license="MIT",
     author="Department for Business and Trade",
@@ -22,7 +22,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "django>=3.2.18,<=4.2.6",
+        "django>=4.2.0,<=4.2.8",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Upgrade to django 4.2x as versions < 4.2.x become end-of-life

 - [ ] Change has a jira ticket that has the correct status.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.

